### PR TITLE
Fixed output for secret_id and added resource id

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | Public certificates secrets manager secret resource ID |
 | <a name="output_secret_crn"></a> [secret\_crn](#output\_secret\_crn) | Public certificates secrets manager secret CRN |
 | <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | Public certificates secrets manager secret unique ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_secret_crn"></a> [secret\_crn](#output\_secret\_crn) | Public certificates secrets manager secret CRN |
-| <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | Public certificates secrets manager secret ID |
+| <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | Public certificates secrets manager secret unique ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 <!-- Leave this section as is so that your module has a link to local development environment set up steps for contributors to follow -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,7 @@
 # Outputs
 ##############################################################################
 
-output "secret_id" {
+output "id" {
   description = "Public certificates secrets manager secret resource ID"
   value       = ibm_sm_public_certificate.secrets_manager_public_certificate.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,8 +3,13 @@
 ##############################################################################
 
 output "secret_id" {
-  description = "Public certificates secrets manager secret ID"
+  description = "Public certificates secrets manager secret resource ID"
   value       = ibm_sm_public_certificate.secrets_manager_public_certificate.id
+}
+
+output "secret_id" {
+  description = "Public certificates secrets manager secret unique ID"
+  value       = ibm_sm_public_certificate.secrets_manager_public_certificate.secret_id
 }
 
 output "secret_crn" {


### PR DESCRIPTION
### Description

Fixed output for secret_id now returning the unique secret_id 
Added the resource id in the output

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fixed output for secret_id now returning the unique secret_id
Added the resource id in the output

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
